### PR TITLE
feat: 자동 로그인과 일반 로그인 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
         "@the-statics/shared-components": "^0.1.7",
+        "axios": "^0.27.2",
+        "joi": "^17.6.0",
         "lodash": "^4.17.21",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
@@ -2184,6 +2186,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
@@ -3116,6 +3131,24 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.3.tgz",
       "integrity": "sha512-WiBSI6JBIhC6LRIsB2Kwh8DsGTlbBU+mLRxJmAe3LjHTdkDpwIbEOZgoXBbZilk/vlfjK8i6nKRAvIRn1XaIMw=="
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
+      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.23.5",
@@ -4736,6 +4769,28 @@
       "integrity": "sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -11209,6 +11264,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/joi": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.0.tgz",
+      "integrity": "sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.3",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "node_modules/js-sha3": {
@@ -18745,6 +18812,19 @@
         }
       }
     },
+    "@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    },
+    "@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
@@ -19408,6 +19488,24 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.3.tgz",
       "integrity": "sha512-WiBSI6JBIhC6LRIsB2Kwh8DsGTlbBU+mLRxJmAe3LjHTdkDpwIbEOZgoXBbZilk/vlfjK8i6nKRAvIRn1XaIMw=="
+    },
+    "@sideway/address": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
+      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@sinclair/typebox": {
       "version": "0.23.5",
@@ -20622,6 +20720,27 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.2.tgz",
       "integrity": "sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA=="
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -25311,6 +25430,18 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "joi": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.0.tgz",
+      "integrity": "sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.3",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "js-sha3": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",
     "@the-statics/shared-components": "^0.1.7",
+    "axios": "^0.27.2",
+    "joi": "^17.6.0",
     "lodash": "^4.17.21",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,31 +1,50 @@
 import "./App.scss";
-import { Routes, Route, useLocation } from "react-router-dom";
+import { Routes, Route } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import { useQuery } from "react-query";
+import axios from "axios";
+
 import WelcomePage from "./pages/WelcomePage";
 import HomePage from "./pages/HomePage";
-import { useEffect, useState } from "react";
 import ProtectedRoutes from "./routes/ProtectedRoutes";
 import SignupPage from "./pages/SignupPage";
 import LoginPage from "./pages/LoginPage";
 import UserFormPage from "./pages/UserFormPage";
 import CoffeeFormPage from "./pages/CoffeeFormPage";
+import { selectUser, setUser } from "./features/user/userSlice";
+import ApiService from "./services/Api";
+
+const ApiInstance = new ApiService(axios);
 
 function App() {
-  const location = useLocation();
+  const dispatch = useDispatch();
+  const user = useSelector(selectUser);
 
-  const [state, setState] = useState("");
+  const { isLoading, data } = useQuery("auth-status-check", ApiInstance.login);
 
-  useEffect(() => {
-    if (window.isNativeApp && window.ReactNativeWebView) {
-      window.ReactNativeWebView.postMessage(JSON.stringify(location.pathname));
-      setState(window.token);
-    }
-  }, [location]);
+  if (isLoading) {
+    return <h1>Loading...</h1>;
+  }
 
-  const isLoggedIn = false;
+  if (data.data.success && window.isNativeApp) {
+    window.ReactNativeWebView.postMessage(`token ${data.data.token}`);
+
+    const { _id, name, email, location } = data.data.user;
+    const user = {
+      id: _id,
+      name,
+      email,
+      location,
+    };
+
+    dispatch(setUser(user));
+  }
+
+  const isLoggedIn = !!user.name;
 
   return (
     <>
-      <h1>Header: {state}</h1>
+      <h1>{JSON.stringify(user)}</h1>
       <Routes>
         <Route element={<ProtectedRoutes isLoggedIn={isLoggedIn} />}>
           <Route path="/" element={<HomePage />} />

--- a/src/App.scss
+++ b/src/App.scss
@@ -2,14 +2,3 @@ body {
   background-color: rgb(255, 255, 255);
   margin: 0 25px;
 }
-
-.logo {
-  position: absolute;
-  top: 150px;
-  width: 100px;
-  height: 100px;
-}
-
-.container {
-  color: red;
-}

--- a/src/features/user/userSlice.js
+++ b/src/features/user/userSlice.js
@@ -1,0 +1,27 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+  id: "",
+  name: "",
+  email: "",
+  location: [],
+};
+
+const userSlice = createSlice({
+  name: "user",
+  initialState: initialState,
+  reducers: {
+    setUser: (state, { payload: { id, name, email, location } }) => {
+      state.id = id;
+      state.name = name;
+      state.email = email;
+      state.location = location;
+    },
+  },
+});
+
+export const selectUser = (state) => state.user;
+
+export const { setUser } = userSlice.actions;
+
+export default userSlice.reducer;

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,22 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import { BrowserRouter } from "react-router-dom";
+import { Provider } from "react-redux";
+import store from "./store/configureStore";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { ReactQueryDevtools } from "react-query/devtools";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 
+const queryClient = new QueryClient();
+
 root.render(
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>
+  <QueryClientProvider client={queryClient}>
+    <Provider store={store}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </Provider>
+    <ReactQueryDevtools initialIsOpen={true} />
+  </QueryClientProvider>
 );

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -1,20 +1,7 @@
-import { useNavigate } from "react-router-dom";
-
 function HomePage() {
-  const navigate = useNavigate();
-
-  const sendToken = () => {
-    if (window.isNativeApp) {
-      window.ReactNativeWebView.postMessage("token: some-token??");
-    }
-  };
-
   return (
     <div>
-      <h1>home page screens</h1>
-      {window.isNativeApp && <h3>this is on WebView</h3>}
-      <button onClick={() => navigate("/welcome")}>To Welcome Page</button>
-      <button onClick={sendToken}>SEND TOKEN TO NATIVE</button>
+      <h1>홈 페이지 입니다.</h1>
     </div>
   );
 }

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -1,26 +1,96 @@
-import "./LoginPage.scss";
+import styles from "./LoginPage.module.scss";
 import { Button, Input } from "@the-statics/shared-components";
 import { useNavigate } from "react-router-dom";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import Joi from "joi";
+import axios from "axios";
+import { useQuery } from "react-query";
+import { useDispatch, useSelector } from "react-redux";
+
+import { selectUser, setUser } from "../features/user/userSlice";
+import ApiService from "../services/Api";
+
+const emailValidator = (email, helper) => {
+  if (email.includes("gmail.com") || email.includes("naver.com")) {
+    return helper.message("회사 메일이 아닙니다.");
+  }
+
+  if (!email.includes("@")) {
+    return helper.message("이메일 형식이 아닙니다.");
+  }
+
+  return email;
+};
+
+const schema = Joi.object({
+  email: Joi.string().custom(emailValidator).required().messages({
+    "string.empty": `이메일을 입력해 주세요.`,
+  }),
+  password: Joi.string().min(3).required().messages({
+    "string.empty": "비밀번호를 입력해 주세요.",
+    "string.min": "비밀번호는 최소 3 자리 이상입니다.",
+  }),
+});
+
+const ApiInstance = new ApiService(axios);
 
 function LoginPage() {
-  const [input, setInput] = useState({ email: "", password: "" });
+  const dispatch = useDispatch();
+  const user = useSelector(selectUser);
 
   const navigate = useNavigate();
 
-  const handleSubmit = (e) => {
+  useEffect(() => {
+    const isLoggedIn = !!user.name;
+
+    if (isLoggedIn) {
+      navigate("/");
+    }
+  }, [user.name, navigate]);
+
+  const [input, setInput] = useState({ email: "", password: "" });
+  const [error, setError] = useState("");
+
+  const { data, refetch } = useQuery(
+    "login",
+    () => ApiInstance.login({ email: input.email, password: input.password }),
+    { enabled: false }
+  );
+
+  const handleSubmit = async (e) => {
     e.preventDefault();
+    const { error } = schema.validate(input);
+
+    if (error) {
+      return setError(error.details[0].message);
+    }
+
+    refetch();
   };
 
+  useEffect(() => {
+    if (data?.data.success) {
+      const user = {
+        id: data.data.user._id,
+        name: data.data.user.name,
+        email: data.data.user.email,
+        location: data.data.user.location,
+      };
+      window.ReactNativeWebView.postMessage(`token ${data.data.token}`);
+      dispatch(setUser(user));
+    }
+
+    if (data?.data.success === false) {
+      setError("로그인 정보가 불일치 합니다.");
+    }
+  }, [data?.data.user, data?.data.success, data?.data.token, dispatch]);
+
   return (
-    <div className="LoginPage">
-      <h1>
-        인풋 테스트: {input.email} - {input.password}
-      </h1>
-      <img src="/icons/app-logo.png" alt="logo" className="logo" />
-      <form className="login-form" onSubmit={handleSubmit}>
-        <div className="login">
-          <div className="login__email">
+    <div className={styles.LoginPage}>
+      <img src="/icons/app-logo.png" alt="logo" className={styles.logo} />
+      <form className={styles["login-form"]} onSubmit={handleSubmit}>
+        <div className={styles.login}>
+          <div className={styles.login__email}>
             <Input
               placeholder="이메일을 입력해 주세요"
               onChange={(e) =>
@@ -28,7 +98,7 @@ function LoginPage() {
               }
             />
           </div>
-          <div className="login__password">
+          <div className={styles.login__password}>
             <Input
               placeholder="비밀번호를 입력해 주세요"
               onChange={(e) =>
@@ -36,8 +106,11 @@ function LoginPage() {
               }
             />
           </div>
-          <div className="login__proceed">
-            <Button>로그인 하기</Button>
+          {error && <span className={styles["error-message"]}>{error}</span>}
+          <div className={styles.login__proceed}>
+            <Button disabled={!input.email || !input.password}>
+              로그인 하기
+            </Button>
           </div>
         </div>
       </form>

--- a/src/pages/LoginPage.module.scss
+++ b/src/pages/LoginPage.module.scss
@@ -1,9 +1,15 @@
+@use "/src/styles/theme";
+
 .LoginPage {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   height: 100vh;
+}
+
+.logo {
+  @include theme.logo-center;
 }
 
 .login-form {
@@ -33,4 +39,8 @@
   width: calc(100% - 50px);
   position: absolute;
   bottom: 50px;
+}
+
+.error-message {
+  font-size: 12px;
 }

--- a/src/pages/WelcomePage.js
+++ b/src/pages/WelcomePage.js
@@ -1,32 +1,46 @@
-import "./WelcomePage.scss";
+import styles from "./WelcomePage.module.scss";
+import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@the-statics/shared-components";
+import { useSelector } from "react-redux";
+
+import { selectUser } from "../features/user/userSlice";
 
 function WelcomePage() {
+  const user = useSelector(selectUser);
+
   const navigate = useNavigate();
 
+  useEffect(() => {
+    const isLoggedIn = !!user.name;
+
+    if (isLoggedIn) {
+      navigate("/");
+    }
+  }, [user.name, navigate]);
+
   return (
-    <div className="WelcomePage">
-      <img src="/icons/app-logo.png" alt="logo" className="logo" />
-      <div className="selection">
-        <div className="selection__login">
+    <div className={styles.WelcomePage}>
+      <img src="/icons/app-logo.png" alt="logo" className={styles.logo} />
+      <div className={styles.selection}>
+        <div className={styles.selection__login}>
           <Button
-            className="selection__login__button-container"
+            className={styles["selection__login__button-container"]}
             onClick={() => navigate("/login")}
           >
             로그인 하기
           </Button>
         </div>
-        <div className="selection__signup">
+        <div className={styles.selection__signup}>
           <Button
-            className="selection__signup__button-container"
+            className={styles["selection__signup__button-container"]}
             onClick={() => navigate("/signup")}
           >
             회원가입 하기
           </Button>
         </div>
       </div>
-      {/* <button onClick={() => navigate("/login")}>To Home Page</button> */}
+      <button onClick={() => navigate("/")}>To Home Page</button>
     </div>
   );
 }

--- a/src/pages/WelcomePage.module.scss
+++ b/src/pages/WelcomePage.module.scss
@@ -1,9 +1,15 @@
+@use "/src/styles/theme";
+
 .WelcomePage {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   height: 100vh;
+}
+
+.logo {
+  @include theme.logo-center;
 }
 
 .selection {

--- a/src/services/Api.js
+++ b/src/services/Api.js
@@ -1,0 +1,18 @@
+class ApiService {
+  constructor(axios) {
+    this.API = axios.create({
+      baseURL: "/",
+      timeout: 5000,
+    });
+
+    this.API.interceptors.request.use((req) => {
+      const token = window.token;
+      req.headers.Authorization = `Bearer ${token}`;
+      return req;
+    });
+  }
+
+  login = (body) => this.API.post("/auth/login", { ...body });
+}
+
+export default ApiService;

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -1,0 +1,11 @@
+import { configureStore } from "@reduxjs/toolkit";
+
+import userSlice from "../features/user/userSlice";
+
+const store = configureStore({
+  reducer: {
+    user: userSlice,
+  },
+});
+
+export default store;

--- a/src/styles/_theme.scss
+++ b/src/styles/_theme.scss
@@ -1,0 +1,5 @@
+@mixin logo-center {
+  position: absolute;
+  top: 150px;
+  width: 100px;
+}


### PR DESCRIPTION
## 설명
### 자동 로그인
유저의 핸드폰에 토큰이 저장되어 있다면 자동으로 헤더에 토큰을 담아서 로그인을 시도합니다. 
만약 성공했다면 '/' 홈페이지 라우트로 이동합니다.

### 직접 로그인
유저의 핸드폰에 토큰이 없다면, 유저가 직접 /login 라우트로 이동해서 이메일과 비밀번호를 입력하고 로그인을 시도합니다.

### 로그인 성공
로그인에 성공했다면 Redux 에 유저 정보를 저장합니다.
또한 서버에서 함께 보내준 JWT 를 React Native 로 전송해서 기기에 저장합니다.

### 힘들었던 점
React Query 를 처음 사용해 봐서 한 번만 요청을 보내는 것과 API 함수를 주입하는 방법을 구하는데 시간을 많이 사용했습니다.

## 변경 또는 추가한 로직

설치한 라이브러리:
1. Joi - input validation 을 위해 Yup 라이브러리와 비교해서 커스텀 에러 메시지를 띄우기 쉬워 Joi 를 선택.
2. axios - interceptor 기능을 사용해서 웹뷰에 주입된 token 을 자동으로 headers.Authorization 에 담을 수 있음.