### PR TITLE
style: 유저 추천 페이지 100vh 넘는 에러 해결

### DIFF
--- a/src/components/UserCard.module.scss
+++ b/src/components/UserCard.module.scss
@@ -11,6 +11,7 @@
   width: 100%;
   height: 100%;
   padding: 10px 0;
+  box-sizing: border-box;
 }
 
 .card__error {


### PR DESCRIPTION
## 설명
유저 추천 화면의 높이가 padding으로 인해 100vh가 넘어가는 문제를 해결하였습니다.

## 변경 또는 추가한 로직
box-sizing을 content-box에서 border-box로 변경하였습니다.