### PR TITLE
fix: 중복된 리디렉션 파일 삭제

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,0 @@
-/* http://Sinderproject-env.eba-p3ciumxi.us-east-1.elasticbeanstalk.com/:splat 200


### PR DESCRIPTION
## 설명

_redirects 파일이 api 리디렉션을 덮어씌우는 문제 해결

## 변경 또는 추가한 로직
