### PR TITLE
feat: netlify.toml 을 삭제하고 _redirects 를 만듦

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,0 @@
-[[redirects]]
-from = "/api/*"
-to = "http://Sinderproject-env.eba-p3ciumxi.us-east-1.elasticbeanstalk.com/:splat"

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,1 @@
+/api/* http://Sinderproject-env.eba-p3ciumxi.us-east-1.elasticbeanstalk.com/:splat 200


### PR DESCRIPTION
## 설명

_redirects 를 삭제했더니 아예 aws 백엔드로 요청을 못보내서 얘를 살리고 netlify.toml 을 삭제했습니다.

## 변경 또는 추가한 로직
