### PR TITLE
React Query 커스텀 훅으로 변경, 상수 따로 정리

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,6 @@
 import "./App.scss";
 import { Routes, Route } from "react-router-dom";
 import { useDispatch } from "react-redux";
-import { useQuery } from "react-query";
-import axios from "axios";
 
 import WelcomePage from "./pages/WelcomePage";
 import HomePage from "./pages/HomePage";
@@ -11,15 +9,13 @@ import SignupPage from "./pages/SignupPage";
 import LoginPage from "./pages/LoginPage";
 import CoffeeFormPage from "./pages/CoffeeFormPage";
 import { setUser } from "./features/user/userSlice";
-import ApiService from "./services/Api";
 import CoffeeLoading from "./components/CoffeeLoading";
-
-const ApiInstance = new ApiService(axios);
+import { useAutoLogin } from "./hooks/auth.hooks";
 
 function App() {
   const dispatch = useDispatch();
 
-  const { isLoading } = useQuery("auto-login", ApiInstance.login, {
+  const { isLoading } = useAutoLogin({
     onSuccess: ({ data }) => {
       if (data.success) {
         if (window.isNativeApp) {

--- a/src/components/UserCardHeartIcon.js
+++ b/src/components/UserCardHeartIcon.js
@@ -1,36 +1,30 @@
 import styles from "./UserCardHeartIcon.module.scss";
-import axios from "axios";
 import { debounce } from "lodash";
 import { useState } from "react";
-import { useMutation } from "react-query";
 import { useSelector } from "react-redux";
 
 import { selectUser } from "../features/user/userSlice";
-import ApiService from "../services/Api";
-
-const ApiInstance = new ApiService(axios);
-
-const emptyHeart = "./icons/white-heart.png";
-const filledHeart = "./icons/white-heart-filled.png";
+import { useLike } from "../hooks/auth.hooks";
+import assets from "../constants/assets";
 
 function UserCardHeartIcon({ onError, userId }) {
   const user = useSelector(selectUser);
 
   const [liked, setLiked] = useState(user.likes.includes(userId));
   const [image, setImage] = useState(
-    user.likes.includes(userId) ? filledHeart : emptyHeart
+    user.likes.includes(userId) ? assets.FILLED_HEART : assets.EMPTY_HEART
   );
 
-  const { mutate } = useMutation((body) => ApiInstance.likeUser({ ...body }), {
+  const { mutate } = useLike({
     onSuccess: ({ data }) => {
       if (!data.success) {
-        setImage(emptyHeart);
+        setImage(assets.EMPTY_HEART);
         setLiked(false);
         onError("요청에 실패했습니다");
       }
     },
     onError: () => {
-      setImage(emptyHeart);
+      setImage(assets.EMPTY_HEART);
       setLiked(false);
       onError("네트워크 요청에 실패했습니다");
     },
@@ -42,7 +36,7 @@ function UserCardHeartIcon({ onError, userId }) {
       to: userId,
     };
 
-    setImage(filledHeart);
+    setImage(assets.FILLED_HEART);
     setLiked(true);
     !liked && mutate(requestBody);
   };

--- a/src/constants/assets.js
+++ b/src/constants/assets.js
@@ -1,0 +1,6 @@
+const assets = {
+  EMPTY_HEART: "./icons/white-heart.png",
+  FILLED_HEART: "./icons/white-heart-filled.png",
+};
+
+export default assets;

--- a/src/constants/queryKeys.js
+++ b/src/constants/queryKeys.js
@@ -1,0 +1,8 @@
+const queryKeys = {
+  AUTO_LOGIN: "auto-login",
+  INFINITE_USERS: "infinite-users",
+  PRICE: "price",
+  LANGUAGES: "languages",
+};
+
+export default queryKeys;

--- a/src/hooks/auth.hooks.js
+++ b/src/hooks/auth.hooks.js
@@ -1,0 +1,37 @@
+import axios from "axios";
+import { useMutation, useQuery } from "react-query";
+
+import queryKeys from "../constants/queryKeys";
+import ApiService from "../services/Api";
+
+const ApiInstance = new ApiService(axios);
+
+export const useAutoLogin = (options) =>
+  useQuery(queryKeys.AUTO_LOGIN, ApiInstance.login, { ...options });
+
+export const useUserPrice = (options) =>
+  useQuery(
+    queryKeys.PRICE,
+    (userId) => ApiInstance.getUserCoffeePrice(userId),
+    {
+      ...options,
+    }
+  );
+
+export const useLanguageSample = (options) =>
+  useQuery(queryKeys.LANGUAGES, ApiInstance.getLanguages, { ...options });
+
+export const useSignUp = (options) =>
+  useMutation((credentials) => ApiInstance.signup({ ...credentials }), {
+    ...options,
+  });
+
+export const useLogin = (options) =>
+  useMutation((userInput) => ApiInstance.login({ ...userInput }), {
+    ...options,
+  });
+
+export const useLike = (options) =>
+  useMutation((requestBody) => ApiInstance.likeUser({ ...requestBody }), {
+    ...options,
+  });

--- a/src/hooks/user.hooks.js
+++ b/src/hooks/user.hooks.js
@@ -1,0 +1,19 @@
+import axios from "axios";
+import { useInfiniteQuery, useMutation } from "react-query";
+
+import queryKeys from "../constants/queryKeys";
+import ApiService from "../services/Api";
+
+const ApiInstance = new ApiService(axios);
+
+export const useCoffeeFormSend = (options) =>
+  useMutation((coffeeForm) => ApiInstance.sendCoffeeForm({ ...coffeeForm }), {
+    ...options,
+  });
+
+export const useInfitniteUsers = (userId, options) =>
+  useInfiniteQuery(
+    queryKeys.INFINITE_USERS,
+    ApiInstance.fetchInfinite(userId),
+    { ...options }
+  );

--- a/src/pages/CoffeeFormPage.js
+++ b/src/pages/CoffeeFormPage.js
@@ -1,14 +1,12 @@
+import styles from "./CoffeeFormPage.module.scss";
 import { Input01, Textarea, Button02 } from "@the-statics/shared-components";
 import { useState } from "react";
-import axios from "axios";
-import { useMutation, useQuery } from "react-query";
 import { useNavigate, useParams } from "react-router-dom";
-import styles from "./CoffeeFormPage.module.scss";
-import ApiService from "../services/Api";
 import { useSelector } from "react-redux";
-import { selectUser } from "../features/user/userSlice";
 
-const ApiInstance = new ApiService(axios);
+import { selectUser } from "../features/user/userSlice";
+import { useUserPrice } from "../hooks/auth.hooks";
+import { useCoffeeFormSend } from "../hooks/user.hooks";
 
 function CoffeeFormPage() {
   const user = useSelector(selectUser);
@@ -26,7 +24,7 @@ function CoffeeFormPage() {
     content: "",
   });
 
-  useQuery("price", ApiInstance.getUserCoffeePrice(userId), {
+  useUserPrice({
     staleTime: Infinity,
     onSuccess: ({ data }) => {
       if (!data.success) {
@@ -40,21 +38,18 @@ function CoffeeFormPage() {
     },
   });
 
-  const { mutate } = useMutation(
-    (coffeeForm) => ApiInstance.sendCoffeeForm({ ...coffeeForm }),
-    {
-      onSuccess: ({ data }) => {
-        if (!data.success) {
-          return setError(data.message);
-        }
+  const { mutate } = useCoffeeFormSend({
+    onSuccess: ({ data }) => {
+      if (!data.success) {
+        return setError(data.message);
+      }
 
-        navigate("/");
-      },
-      onError: () => {
-        setError("네트워크 요청을 실패했습니다.");
-      },
-    }
-  );
+      navigate("/", { replace: true });
+    },
+    onError: () => {
+      setError("네트워크 요청을 실패했습니다.");
+    },
+  });
 
   const handleChange = (type) => (e) => {
     setInput((prev) => ({ ...prev, [type]: e.target.value }));

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -1,15 +1,11 @@
 import styles from "./HomePage.module.scss";
 import { useCallback, useRef } from "react";
 import { useSelector } from "react-redux";
-import { useInfiniteQuery } from "react-query";
-import axios from "axios";
 
 import { selectUser } from "../features/user/userSlice";
 import UserCard from "../components/UserCard";
-import ApiService from "../services/Api";
 import CoffeeLoading from "../components/CoffeeLoading";
-
-const ApiInstance = new ApiService(axios);
+import { useInfitniteUsers } from "../hooks/user.hooks";
 
 function HomePage() {
   const user = useSelector(selectUser);
@@ -20,7 +16,7 @@ function HomePage() {
     hasNextPage,
     fetchNextPage,
     refetch,
-  } = useInfiniteQuery("users", ApiInstance.fetchInfinite(user.id), {
+  } = useInfitniteUsers(user.id, {
     staleTime: Infinity,
     getNextPageParam: (lastPage) => {
       if (lastPage.data.isLastPage) return;

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -2,16 +2,12 @@ import styles from "./LoginPage.module.scss";
 import { Button02, Input01 } from "@the-statics/shared-components";
 import { useNavigate } from "react-router-dom";
 import { useState } from "react";
-import axios from "axios";
-import { useMutation } from "react-query";
 import { useDispatch } from "react-redux";
 
 import { setUser } from "../features/user/userSlice";
-import ApiService from "../services/Api";
 import { LogInSchema } from "../services/Validation";
 import { wait } from "../utils/helpers";
-
-const ApiInstance = new ApiService(axios);
+import { useLogin } from "../hooks/auth.hooks";
 
 function LoginPage() {
   const dispatch = useDispatch();
@@ -21,7 +17,7 @@ function LoginPage() {
   const [input, setInput] = useState({ email: "", password: "" });
   const [error, setError] = useState("");
 
-  const { mutate } = useMutation((input) => ApiInstance.login({ ...input }), {
+  const { mutate } = useLogin({
     onSuccess: async ({ data }) => {
       if (!data.success) {
         return setError("로그인 정보가 불일치 합니다.");

--- a/src/pages/SignupPage.js
+++ b/src/pages/SignupPage.js
@@ -6,19 +6,15 @@ import {
 } from "@the-statics/shared-components";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import memoize from "fast-memoize";
-import axios from "axios";
 import { debounce } from "lodash";
 import { useDispatch } from "react-redux";
 import { useNavigate } from "react-router-dom";
-import { useMutation, useQuery } from "react-query";
 
 import styles from "./SignupPage.module.scss";
 import SelectLanguage from "../components/SelectLanguage";
-import ApiService from "../services/Api";
 import { setUser } from "../features/user/userSlice";
 import { SignUpSchema } from "../services/Validation";
-
-const ApiInstance = new ApiService(axios);
+import { useLanguageSample, useSignUp } from "../hooks/auth.hooks";
 
 function SignupPage() {
   const dispatch = useDispatch();
@@ -43,41 +39,38 @@ function SignupPage() {
 
   const img = useMemo(() => base64, [base64]);
 
-  const mutation = useMutation(
-    (credentials) => ApiInstance.signup({ ...credentials }),
-    {
-      onSuccess: ({ data }) => {
-        if (!data.success) {
-          return setError(data.message);
-        }
+  const { mutate } = useSignUp({
+    onSuccess: ({ data }) => {
+      if (!data.success) {
+        return setError(data.message);
+      }
 
-        if (window.ReactNativeWebView) {
-          window.ReactNativeWebView.postMessage(`token ${data.token}`);
-        }
+      if (window.ReactNativeWebView) {
+        window.ReactNativeWebView.postMessage(`token ${data.token}`);
+      }
 
-        const user = {
-          id: data.user._id,
-          name: data.user.name,
-          email: data.user.email,
-          image: data.user.image,
-          languages: data.user.languages,
-          expertise: data.user.expertise,
-          price: data.user.price,
-          likes: data.user.likes,
-          match: data.user.match,
-          location: data.user.location,
-        };
+      const user = {
+        id: data.user._id,
+        name: data.user.name,
+        email: data.user.email,
+        image: data.user.image,
+        languages: data.user.languages,
+        expertise: data.user.expertise,
+        price: data.user.price,
+        likes: data.user.likes,
+        match: data.user.match,
+        location: data.user.location,
+      };
 
-        dispatch(setUser(user));
-        navigate("/", { replace: true });
-      },
-      onError: () => {
-        setError("네트워크 요청을 실패했습니다.");
-      },
-    }
-  );
+      dispatch(setUser(user));
+      navigate("/", { replace: true });
+    },
+    onError: () => {
+      setError("네트워크 요청을 실패했습니다.");
+    },
+  });
 
-  const { data } = useQuery("languages", ApiInstance.getLanguages, {
+  const { data } = useLanguageSample({
     staleTime: Infinity,
   });
 
@@ -103,7 +96,7 @@ function SignupPage() {
       return setError(error.details[0].message);
     }
 
-    mutation.mutate({ ...credentials, base64 });
+    mutate({ ...credentials, base64 });
   };
 
   const openGallery = () => {


### PR DESCRIPTION
## 설명

React Query 의 훅을 (useQuery, useMutation 등..) 컴포넌트에서 직접 사용하지 않고 커스텀 훅으로 만들었습니다.
그리고 컴포넌트에서 직접 문자열로 입력해주었던 쿼리 키와 이미지 url 을 Constants 폴더에 정리했습니다.

## 변경 또는 추가한 로직
